### PR TITLE
Remove unnecessary flow script

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,6 @@
   },
   "scripts": {
     "clean": "rm -rf dist",
-    "flow": "flow check",
     "lint": "eslint . --ignore-path .gitignore",
     "build-test": "rm -rf dist-tests && cup build-tests",
     "just-test": "node_modules/.bin/unitest --browser=dist-tests/browser.js --node=dist-tests/node.js",


### PR DESCRIPTION
Currently no OSS Fusion.js plugins define the flow script, which our release-verification process makes some assumptions around. We might adjust this in the future, but for now remove the flow script.

See fusion-core for an example: https://github.com/fusionjs/fusion-core/blob/c0dd5b998d51f6d9c8b08894a5bd437627a3e6f5/package.json#L25-L36